### PR TITLE
Add java-11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,20 @@
             <artifactId>json</artifactId>
             <version>20190722</version>
         </dependency>
+
+        <!-- API, java.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+
+        <!-- Runtime, com.sun.xml.bind module -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR adds jaxb dependencies

JAXB apis are removed from java SE 9 and therefore has to be added as
separate dependencies.

For more details: https://stackoverflow.com/a/43574427

---

Have tested that this works on these:

* tomcat8 with java-11 after compiling with java-11 
* tomcat8 with java-8 after compiling with java-8