### PR TITLE
Tiny fixes that make shape upload not error out on uploading first file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,20 @@
             <artifactId>json</artifactId>
             <version>20190722</version>
         </dependency>
+
+        <!-- API, java.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+
+        <!-- Runtime, com.sun.xml.bind module -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/strandls/naksha/controller/LayerController.java
+++ b/src/main/java/com/strandls/naksha/controller/LayerController.java
@@ -108,6 +108,8 @@ public class LayerController {
 					.entity("{\"responseCode\":" + i + ", \"info\": \"1 = failure && 0 = Success\"}").build();
 
 		} catch (Exception e) {
+			System.out.println("CRASHED: " + e.toString() + e.getMessage());
+			e.printStackTrace();
 			throw new WebApplicationException(
 					Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build());
 

--- a/src/main/java/com/strandls/naksha/layers/scripts/DBexec.java
+++ b/src/main/java/com/strandls/naksha/layers/scripts/DBexec.java
@@ -16,11 +16,10 @@ import com.strandls.naksha.NakshaConfig;
 public class DBexec {
 	public static int main_func_generation(String sql_fl, String dbname, String dbpassword, String dbuser) {
 		try {
-			String password = "hum123";
 			String dbhost = NakshaConfig.getString("geoserver.dbhost");
 			ProcessBuilder builder = new ProcessBuilder("bash", "-c", "PGPASSWORD=" + dbpassword
 					+ " psql -h " + dbhost + " -d " + dbname + " -a -U " + dbuser + " -f " + sql_fl);
-			Process process = builder.start();
+			Process process = builder.inheritIO().start();
 			System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
 			System.out.println(process);
 			int i = process.getErrorStream().available();
@@ -33,6 +32,7 @@ public class DBexec {
 			process.waitFor();
 			return i;
 		} catch (Error | Exception ex) {
+			ex.printStackTrace();
 			return 1;
 		}
 

--- a/src/main/java/com/strandls/naksha/layers/scripts/Import_layers.java
+++ b/src/main/java/com/strandls/naksha/layers/scripts/Import_layers.java
@@ -472,7 +472,7 @@ public class Import_layers {
 				+ "COMMENT ON COLUMN \"%s\".__mlocate__validated_by IS 'Validated By';\n"
 				+ "COMMENT ON COLUMN \"%s\".__mlocate__validated_date IS 'Validated Date';\n";
 
-		layer_colcomments = layer_colcomments.replace("%s", layer_tablename);
+		layer_colcomments = layer_colcomments.replace("%s", layer_tablename.toLowerCase());
 		// here x is keysStr
 
 		while (keys.hasNext()) {

--- a/src/main/java/com/strandls/naksha/layers/scripts/generate_geoserver_layers.java
+++ b/src/main/java/com/strandls/naksha/layers/scripts/generate_geoserver_layers.java
@@ -239,7 +239,7 @@ public class generate_geoserver_layers {
 
 	private static String get_keywords_xml(String tablename) throws SQLException {
 
-		String[] layer_keywords = null;
+		String[] layer_keywords;
 		String keywords_xml = "";
 		String layer_keywords_query = "select tags from \"Meta_Layer\" where layer_tablename='" + tablename + "'";
 		ResultSet rs = stmt.executeQuery(layer_keywords_query);
@@ -249,7 +249,7 @@ public class generate_geoserver_layers {
 		if (!layer_keywords_results.isEmpty() && layer_keywords_results != null) {
 			layer_keywords = layer_keywords_results.split(",");
 		} else {
-			layer_keywords[0] = "Miscellaneous";
+			layer_keywords = new String[]{"Miscellaneous"};
 		}
 
 		for (String keyword : layer_keywords) {

--- a/src/main/resource/config.properties
+++ b/src/main/resource/config.properties
@@ -26,3 +26,6 @@ basePath=/naksha-api/api
 resourcePackage=com.strandls.naksha
 prettyPrint=true
 scan=true
+GEOSERVER_DBNAME=ibp
+GEOSERVER_DBUSER=postgres
+GEOSERVER_PASS=postgres123


### PR DESCRIPTION
This PR is the result of digging through the files mentioned in #4 to make the server accept the shape files at https://github.com/datameet/maps/tree/master/States when starting from an empty database.

Included fix for
* Handling shape files with capital letter names (as shp2pgsql automatically converts them to lower case)
* Making errors prominent (so that debugging is easier)
* Adding three parameters (GEOSERVER_DBNAME, GEOSERVER_DBUSER, GEOSERVER_PASS) in config.properties as they are used in the code
* A null-pointer exception in the wild.